### PR TITLE
[FIX]: changed default width of inputs in front app details page

### DIFF
--- a/v6y-apps/front/src/features/app-details/components/BranchSelector.tsx
+++ b/v6y-apps/front/src/features/app-details/components/BranchSelector.tsx
@@ -14,7 +14,7 @@ interface BranchSelectorProps {
 const BranchSelector = ({ branches, selectedBranch, onBranchChange }: BranchSelectorProps) => {
     return (
         <Select value={selectedBranch} onValueChange={onBranchChange}>
-            <SelectTrigger className="h-10 sm:h-8 w-full sm:w-[320px] border-slate-300 rounded-md px-3 sm:px-4 py-2 text-sm bg-white">
+            <SelectTrigger className="h-10 sm:h-8 w-fit border-slate-300 rounded-md px-3 sm:px-4 py-2 text-sm bg-white">
                 <span className="flex min-w-0 items-center gap-1 truncate">
                     <ShuffleIcon className="w-4 h-4 shrink-0" />
                     <SelectValue className="truncate" />

--- a/v6y-apps/front/src/features/app-details/components/VitalityAppDetailsView.tsx
+++ b/v6y-apps/front/src/features/app-details/components/VitalityAppDetailsView.tsx
@@ -183,7 +183,7 @@ const VitalityAppDetailsView = () => {
 
                             <Input
                                 type="date"
-                                className="h-10 sm:h-8 border-slate-300 rounded-md text-sm"
+                                className="h-10 sm:h-8 w-fit border-slate-300 rounded-md text-sm"
                                 value={selectedDate}
                                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                                     setSelectedDate(e.target.value)


### PR DESCRIPTION
### Before
<img src="https://github.com/user-attachments/assets/9ff97c38-70d4-405a-9366-7800f38b4d14" alt="Screenshot 1" height="200" style="width: auto;">

### After
<img src="https://github.com/user-attachments/assets/fdefdca7-629b-4123-936b-240755ac554e" alt="Screenshot 2" height="200" style="width: auto;">


