### PR TITLE
refactor: optimize docker-compose for local dev, skip registry pulls

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -102,16 +102,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update docker-compose.yml with dynamic image names
-        run: |
-          sed -i "s|<registry-owner>|${{ github.repository_owner }}|g" docker-compose.yml
-          sed -i "s|:latest|:${{ env.IMAGE_TAG }}|g" docker-compose.yml
-
       - name: Validate Docker Compose Configuration
         run: docker-compose -f docker-compose.yml config
 
       - name: Build and push images using Docker Compose
         run: |
+          export REGISTRY="ghcr.io/${{ github.repository_owner }}/"
+          export IMAGE_TAG="${{ env.IMAGE_TAG }}"
           docker-compose -f docker-compose.yml build
           docker-compose -f docker-compose.yml push
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,9 @@ services:
       timeout: 5s
       retries: 5
   v6y-migrate:
-    extends:
-      file: docker-compose.base.yml
-      service: v6y-service-base
-    command: pnpm --filter @v6y/core-logic db:migrate:deploy
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-bff:latest
+    build:
+      context: .
+      dockerfile: v6y-config/Dockerfile.migrations
     environment:
       - PSQL_DB_HOST=${PSQL_DB_HOST}
       - PSQL_DB_NAME=${PSQL_DB_NAME}
@@ -31,6 +29,9 @@ services:
       v6y-database:
         condition: service_healthy
     restart: "no"
+    volumes:
+      - ./:/app
+      - mono-node-modules:/app/node_modules
 
   v6y-bff:
     extends:
@@ -39,7 +40,6 @@ services:
     command: pnpm run start:bff
     ports:
       - "4001:4001"
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-bff:latest
     environment:
       - PSQL_DB_HOST=${PSQL_DB_HOST}
       - PSQL_DB_NAME=${PSQL_DB_NAME}
@@ -67,7 +67,6 @@ services:
     command: pnpm run start:bfb:main
     ports:
       - "4002:4002"
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-bfb-main-analyzer:latest
     environment:
       - PSQL_DB_HOST=${PSQL_DB_HOST}
       - PSQL_DB_NAME=${PSQL_DB_NAME}
@@ -97,7 +96,6 @@ services:
     command: pnpm run start:bfb:static
     ports:
       - "4003:4003"
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-bfb-static-code-auditor:latest
     environment:
       - PSQL_DB_HOST=${PSQL_DB_HOST}
       - PSQL_DB_NAME=${PSQL_DB_NAME}
@@ -125,7 +123,6 @@ services:
     command: pnpm run start:bfb:dynamic
     ports:
       - "4004:4004"
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-bfb-url-dynamic-auditor:latest
     environment:
       - PSQL_DB_HOST=${PSQL_DB_HOST}
       - PSQL_DB_NAME=${PSQL_DB_NAME}
@@ -153,7 +150,6 @@ services:
     command: pnpm run start:bfb:devops
     ports:
       - "4005:4005"
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-bfb-devops-auditor:latest
     environment:
       - PSQL_DB_HOST=${PSQL_DB_HOST}
       - PSQL_DB_NAME=${PSQL_DB_NAME}
@@ -181,7 +177,6 @@ services:
     command: pnpm run start:frontend
     ports:
       - "4006:4006"
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-frontend:latest
     environment:
       - NEXT_PUBLIC_V6Y_BFF_PATH=${NEXT_PUBLIC_V6Y_BFF_PATH}
     healthcheck:
@@ -197,7 +192,6 @@ services:
     command: pnpm run start:frontend:bo
     ports:
       - "4008:4008"
-    image: ghcr.io/${REGISTRY_OWNER}/v6y-frontend-bo:latest
     environment:
       - NEXT_PUBLIC_V6Y_BFF_PATH=${NEXT_PUBLIC_V6Y_BFF_PATH}
       - NEXTAUTH_URL=${NEXTAUTH_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       timeout: 5s
       retries: 5
   v6y-migrate:
+    image: ${REGISTRY}v6y-migrate:${IMAGE_TAG}
+    pull_policy: build
     build:
       context: .
       dockerfile: v6y-config/Dockerfile.migrations
@@ -34,6 +36,8 @@ services:
       - mono-node-modules:/app/node_modules
 
   v6y-bff:
+    image: ${REGISTRY}v6y-bff:${IMAGE_TAG}
+    pull_policy: build
     extends:
       file: docker-compose.base.yml
       service: v6y-service-base
@@ -61,6 +65,8 @@ services:
       retries: 3
 
   v6y-bfb-main-analyzer:
+    image: ${REGISTRY}v6y-bfb-main-analyzer:${IMAGE_TAG}
+    pull_policy: build
     extends:
       file: docker-compose.base.yml
       service: v6y-service-base
@@ -90,6 +96,8 @@ services:
       retries: 3
 
   v6y-bfb-static-code-auditor:
+    image: ${REGISTRY}v6y-bfb-static-code-auditor:${IMAGE_TAG}
+    pull_policy: build
     extends:
       file: docker-compose.base.yml
       service: v6y-service-base
@@ -117,6 +125,8 @@ services:
       retries: 3
 
   v6y-bfb-url-dynamic-auditor:
+    image: ${REGISTRY}v6y-bfb-url-dynamic-auditor:${IMAGE_TAG}
+    pull_policy: build
     extends:
       file: docker-compose.base.yml
       service: v6y-service-base
@@ -144,6 +154,8 @@ services:
       retries: 3
 
   v6y-bfb-devops-auditor:
+    image: ${REGISTRY}v6y-bfb-devops-auditor:${IMAGE_TAG}
+    pull_policy: build
     extends:
       file: docker-compose.base.yml
       service: v6y-service-base
@@ -171,6 +183,8 @@ services:
       retries: 3
 
   v6y-frontend:
+    image: ${REGISTRY}v6y-frontend:${IMAGE_TAG}
+    pull_policy: build
     extends:
       file: docker-compose.base.yml
       service: v6y-service-base
@@ -186,6 +200,8 @@ services:
       retries: 3
 
   v6y-frontend-bo:
+    image: ${REGISTRY}v6y-frontend-bo:${IMAGE_TAG}
+    pull_policy: build
     extends:
       file: docker-compose.base.yml
       service: v6y-service-base

--- a/env-template
+++ b/env-template
@@ -32,4 +32,8 @@ V6Y_BFF_API_PORT=4001
 NEXT_PUBLIC_V6Y_BFF_PATH=xxxx
 NEXTAUTH_URL=xxxx
 
-REGISTRY_OWNER=x
+# Docker Registry
+# For local development, keep REGISTRY empty to use simple image names (e.g., v6y-bff:latest)
+# For CI/CD, this is set to ghcr.io/ekino/ by the workflow
+REGISTRY=
+IMAGE_TAG=latest

--- a/v6y-apps/front-bo/next-env.d.ts
+++ b/v6y-apps/front-bo/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/v6y-apps/front/next-env.d.ts
+++ b/v6y-apps/front/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/v6y-config/Dockerfile.migrations
+++ b/v6y-config/Dockerfile.migrations
@@ -1,0 +1,11 @@
+ARG NODE_VERSION=22-alpine
+FROM node:${NODE_VERSION}
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install -g pnpm@10.20.0
+RUN pnpm install
+
+CMD ["pnpm", "--filter", "@v6y/core-logic", "db:migrate:deploy"]


### PR DESCRIPTION
- Update .env to use container hostname (v6y-database) instead of localhost for DB connection
- Remove hardcoded GHCR image references from all services to force local builds
- Create lightweight Dockerfile.migrations that skips `pnpm run build` for faster migrations
- Update v6y-migrate service to use dedicated migrations Dockerfile

This allows running `docker compose up v6y-database v6y-migrate` without:
- GHCR authentication
- Building entire frontend monorepo