### PR TITLE
[FIX]: fix analyzer config and TypeScript workspace warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ]
+}

--- a/v6y-apps/bfb-main-analyzer/eslint.config.mjs
+++ b/v6y-apps/bfb-main-analyzer/eslint.config.mjs
@@ -1,7 +1,10 @@
 import eslint from '@eslint/js';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import { fileURLToPath } from 'node:url';
 import globals from 'globals';
 import tsEslint from 'typescript-eslint';
+
+const tsconfigRootDir = fileURLToPath(new URL('.', import.meta.url));
 
 export default [
     {
@@ -14,6 +17,11 @@ export default [
     {
         name: 'analyzer:source',
         files: ['src/**/*.{js,mjs,ts,tsx}'],
+        languageOptions: {
+            parserOptions: {
+                tsconfigRootDir,
+            },
+        },
         rules: {
             'max-depth': ['error', 3],
             'max-nested-callbacks': ['error', 3],
@@ -27,6 +35,11 @@ export default [
     {
         name: 'analyzer:tests',
         files: ['src/**/__tests__/**/*-test.{ts,js}', 'src/**/*.test.{ts,js,tsx}'],
+        languageOptions: {
+            parserOptions: {
+                tsconfigRootDir,
+            },
+        },
         rules: {
             'max-lines-per-function': 'off',
             'max-lines': 'off',

--- a/v6y-apps/bfb-main-analyzer/src/config/ServerConfig.ts
+++ b/v6y-apps/bfb-main-analyzer/src/config/ServerConfig.ts
@@ -12,7 +12,7 @@ const SERVER_ENV_CONFIGURATION = {
         apiPath: process.env.V6Y_MAIN_API_PATH,
         staticAuditorApiPath: process.env.V6Y_STATIC_ANALYZER_API_PATH,
         dynamicAuditorApiPath: process.env.V6Y_DYNAMIC_ANALYZER_API_PATH,
-        devopsAuditorApiPath: process.env.V6Y_DEVOPS_ANALYSER_API_PATH,
+        devopsAuditorApiPath: process.env.V6Y_DEVOPS_API_PATH,
         healthCheckPath: V6Y_HEALTH_CHECK_PATH,
         monitoringPath: V6Y_MONITORING_PATH,
         serverTimeout: 900000, // milliseconds
@@ -24,7 +24,7 @@ const SERVER_ENV_CONFIGURATION = {
         apiPath: process.env.V6Y_MAIN_API_PATH,
         staticAuditorApiPath: process.env.V6Y_STATIC_ANALYZER_API_PATH,
         dynamicAuditorApiPath: process.env.V6Y_DYNAMIC_ANALYZER_API_PATH,
-        devopsAuditorApiPath: process.env.V6Y_DEVOPS_ANALYSER_API_PATH,
+        devopsAuditorApiPath: process.env.V6Y_DEVOPS_API_PATH,
         healthCheckPath: V6Y_HEALTH_CHECK_PATH,
         monitoringPath: V6Y_MONITORING_PATH,
         serverTimeout: 900000, // milliseconds

--- a/v6y-apps/bfb-main-analyzer/tsconfig.json
+++ b/v6y-apps/bfb-main-analyzer/tsconfig.json
@@ -5,6 +5,7 @@
     /* Modules */
     "module": "NodeNext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "NodeNext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
     /* Emit */

--- a/v6y-apps/bff/tsconfig.json
+++ b/v6y-apps/bff/tsconfig.json
@@ -5,6 +5,7 @@
     /* Modules */
     "module": "NodeNext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "NodeNext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
     /* Emit */
@@ -21,6 +22,9 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
+  "include": [
+    "src/**/*.ts"
+  ],
   "ts-node": {
     "experimentalSpecifierResolution": "node",
     "transpileOnly": true,

--- a/v6y-apps/front-bo/tsconfig.json
+++ b/v6y-apps/front-bo/tsconfig.json
@@ -14,7 +14,6 @@
     "allowImportingTsExtensions": true,
     "module": "ESNext",
     "target": "ES2023",
-    "downlevelIteration": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/v6y-apps/front/tsconfig.json
+++ b/v6y-apps/front/tsconfig.json
@@ -13,7 +13,6 @@
     "allowImportingTsExtensions": true,
     "module": "ESNext",
     "target": "ES2023",
-    "downlevelIteration": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/v6y-libs/ui-kit-front/tsconfig.json
+++ b/v6y-libs/ui-kit-front/tsconfig.json
@@ -13,7 +13,6 @@
     "allowImportingTsExtensions": true,
     "module": "ESNext",
     "target": "ES2023",
-    "downlevelIteration": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/v6y-libs/ui-kit/tsconfig.json
+++ b/v6y-libs/ui-kit/tsconfig.json
@@ -13,7 +13,6 @@
     "allowImportingTsExtensions": true,
     "module": "ESNext",
     "target": "ES2023",
-    "downlevelIteration": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
corrected the main analyzer’s DevOps env var reference, cleaned up the declaration tsconfig layout in the BFF and main analyzer, removed the deprecated downlevelIteration flag from the affected package tsconfigs, and added analyzer ESLint [tsconfigRootDir](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) handling so the monorepo file stopped tripping the parser warning. I also added a workspace ESLint setting for auto-working directories. pnpm lint completed successfully.