### PR TITLE
[FIX]: make knip CI job blocking

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -10,7 +10,6 @@ jobs:
   knip:
     name: Check for unused code and dependencies
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Part of the #421 knip cleanup, stacked on #431. Last PR in the stack.

Now that the whole monorepo is knip-clean (zero unused files/deps/exports across all workspaces), removes `continue-on-error: true` from `.github/workflows/knip.yml` so future regressions fail CI instead of being silently ignored.

Closes #421
