### PR TITLE
chore(deps): bump ecoindex to 2.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,8 +248,8 @@ catalogs:
       specifier: '=17.2.3'
       version: 17.2.3
     ecoindex:
-      specifier: '=1.0.7'
-      version: 1.0.7
+      specifier: '=2.0.1'
+      version: 2.0.1
     express-status-monitor:
       specifier: '=1.3.4'
       version: 1.3.4
@@ -774,7 +774,7 @@ importers:
         version: 4.1.0
       ecoindex:
         specifier: 'catalog:'
-        version: 1.0.7
+        version: 2.0.1
       express-status-monitor:
         specifier: 'catalog:'
         version: 1.3.4
@@ -7277,9 +7277,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
-  ecoindex@1.0.7:
-    resolution: {integrity: sha512-0fJWWWuJ2T9ykpvZ0O6MJX/qMjZ/Z17s4tWvfEWxAuX8YuhVKZ2LXdrUu67cs2FFdHck2oeUP7Uf4NGefGdQfQ==}
-    engines: {node: '>=16.0.0 <18.20.0'}
+  ecoindex@2.0.1:
+    resolution: {integrity: sha512-62wNhERrLcrJ7ItG1BXCOEGZCWt2f9wHq1nXua73tQ/2PKV1vup5Kj2bQiqQxBzslmNYQ8H79CQOtyHbmiQqxA==}
+    engines: {node: '>=18.20.0'}
 
   ecoindex_reference@1.0.2:
     resolution: {integrity: sha512-IKse3tu6IQfhrpGsVuxmC1K4xlc1FCZtaNYjLUj+Yxm5wthuVyS7C/miVPqSN7UZaNViUO2013ri+WJJhZfCUA==}
@@ -18135,7 +18135,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  ecoindex@1.0.7:
+  ecoindex@2.0.1:
     dependencies:
       ecoindex_reference: 1.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -106,7 +106,7 @@ catalogs:
     'crypto-hash': '=4.0.0'
     'date-fns': '=4.1.0'
     'dotenv': '=17.2.3'
-    'ecoindex': '=1.0.7'
+    'ecoindex': '=2.0.1'
     'express-status-monitor': '=1.3.4'
     'file-saver': '=2.0.5'
     'fs-extra': '=11.2.0'


### PR DESCRIPTION
## Why

The `ecoindex` catalog pin was bumped from `1.0.7` to `2.0.1` (latest published version) as an accidental side effect of an unrelated commit on another branch. This PR isolates that dependency bump on its own so it can be reviewed/merged independently.

## What

- `pnpm-workspace.yaml`: bump the `ecoindex` catalog pin to `2.0.1`
- `pnpm-lock.yaml`: regenerated accordingly

## Validation

- `bfb-dynamic-auditor` (the only consumer of `ecoindex`) lints cleanly against the new version.
- No ecoindex-related type errors introduced (pre-existing, unrelated Prisma client generation errors are present in a fresh checkout regardless of this change).
