### PR TITLE
fix(ui-kit-front): avoid hydration mismatch in LanguageMenu

### DIFF
--- a/v6y-libs/ui-kit-front/src/components/organisms/LanguageMenu.tsx
+++ b/v6y-libs/ui-kit-front/src/components/organisms/LanguageMenu.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { useIsClient } from '../../hooks/useIsClient.ts';
 import { useTranslationProvider } from '../../translation/useTranslationProvider';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../molecules';
 
@@ -22,7 +23,13 @@ const Flag = ({ code, label }: { code: string; label: string }) => (
 
 const LanguageMenu = () => {
     const { getLocale, changeLocale } = useTranslationProvider();
-    const currentLocale = getLocale();
+    const isClient = useIsClient();
+    const detectedLocale = getLocale();
+    // The i18next language detector only resolves the browser's preferred
+    // language on the client. Rendering it before hydration completes would
+    // mismatch the server-rendered fallback language, so keep the fallback
+    // until the client has taken over.
+    const currentLocale = isClient ? detectedLocale : 'en';
     const currentLanguage = languages.find((lang) => lang.code === currentLocale) || languages[0];
 
     return (

--- a/v6y-libs/ui-kit-front/src/hooks/index.ts
+++ b/v6y-libs/ui-kit-front/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useIsClient';
 export * from './useNavigationAdapter';

--- a/v6y-libs/ui-kit-front/src/hooks/useIsClient.ts
+++ b/v6y-libs/ui-kit-front/src/hooks/useIsClient.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const emptySubscribe = () => () => {};
+
+/**
+ * Returns true only once the component has hydrated on the client.
+ * Useful to defer client-only data (e.g. browser-detected locale) until after
+ * hydration, avoiding server/client markup mismatches, without resorting to a
+ * `useState` + `useEffect` "mounted" flag (which itself trips
+ * react-hooks/set-state-in-effect).
+ */
+export const useIsClient = () =>
+    useSyncExternalStore(
+        emptySubscribe,
+        () => true,
+        () => false,
+    );


### PR DESCRIPTION
## Problem
Next.js hydration error on the `front` app's `LanguageMenu` (Radix `Select` + flag). The rendered flag (`gb` vs `fr`) and locale differ between server and client output.

## Root cause
`i18next-browser-languagedetector` can only resolve the user's stored/browser locale (cookie/localStorage/navigator) on the client. During SSR none of those APIs are available, so `i18n.language` resolves to `fallbackLng: 'en'`. `LanguageMenu` rendered `getLocale()` immediately, so whenever a user's detected locale differs from the fallback (e.g. `fr`), the server-rendered markup (English/`gb` flag) didn't match the client's first render (French/`fr` flag) — a classic hydration mismatch.

## Fix
Added a `useIsClient` hook (`useSyncExternalStore`-based, avoids the `react-hooks/set-state-in-effect` lint pattern) and use it in `LanguageMenu` to keep rendering the `'en'` fallback until the client has hydrated, then switch to the real detected locale.

## Testing
- `pnpm --filter @v6y/ui-kit-front lint` passes
- `nx run-many --target=test --all` passes (via pre-push hook)
