### PR TITLE
[FIX]: repair the port collision and GitHub DORA false success left by merging #454

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - V6Y_BFF_API_PATH=${V6Y_BFF_API_PATH}
       - V6Y_BFF_API_PORT=${V6Y_BFF_API_PORT}
-      - V6Y_MAIN_ANALYZER_TRIGGER_API_PATH=http://v6y-bfb-main-analyzer:4005/v6y/bfb-main/trigger-application-analysis.json
+      - V6Y_MAIN_ANALYZER_TRIGGER_API_PATH=http://v6y-bfb-main-analyzer:4002/v6y/bfb-main/trigger-application-analysis.json
     depends_on:
       v6y-migrate:
         condition: service_completed_successfully
@@ -85,7 +85,7 @@ services:
       service: v6y-service-base
     command: pnpm run start:bfb:main
     ports:
-      - "4005:4005"
+      - "4002:4002"
     environment:
       - PSQL_DB_HOST=${PSQL_DB_HOST}
       - PSQL_DB_NAME=${PSQL_DB_NAME}
@@ -112,7 +112,7 @@ services:
       v6y-redis:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:4005/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:4002/health" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/v6y-apps/bfb-devops-auditor/src/__tests__/DoraMetricsAuditor.test.ts
+++ b/v6y-apps/bfb-devops-auditor/src/__tests__/DoraMetricsAuditor.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const getApplicationDetailsInfoByParams = vi.fn();
+const getRepositoryDetails = vi.fn();
+const insertAuditList = vi.fn();
+
+vi.mock('@v6y/core-logic', async () => {
+    const actual = await vi.importActual<typeof import('@v6y/core-logic')>('@v6y/core-logic');
+
+    return {
+        ...actual,
+        ApplicationProvider: { getApplicationDetailsInfoByParams },
+        RepositoryApi: { ...actual.RepositoryApi, getRepositoryDetails },
+        AuditProvider: { ...actual.AuditProvider, insertAuditList },
+    };
+});
+
+const { default: DoraMetricsAuditor } = await import(
+    '../auditors/dora-metrics/DoraMetricsAuditor.ts'
+);
+
+const application = (webUrl: string) => ({
+    _id: 1,
+    repo: {
+        organization: 'ekino',
+        gitUrl: 'https://github.com/ekino/v6y.git',
+        webUrl,
+    },
+});
+
+describe('DoraMetricsAuditor', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('skips a GitHub-hosted repository instead of reporting empty metrics as success', async () => {
+        // DORA is computed from GitLab-only endpoints, and the fetch helpers default to
+        // GitLab URLs. Proceeding with a GitHub repository id would query GitLab with
+        // it, get nothing back, and store empty metrics as a clean success.
+        getApplicationDetailsInfoByParams.mockResolvedValue(
+            application('https://github.com/ekino/v6y'),
+        );
+
+        const outcome = await DoraMetricsAuditor.startAuditorAnalysis({ applicationId: 1 });
+
+        expect(outcome.status).toBe('skipped');
+        expect(outcome.message).toContain('GitLab-hosted');
+        expect(getRepositoryDetails).not.toHaveBeenCalled();
+        expect(insertAuditList).not.toHaveBeenCalled();
+    });
+
+    it('skips when no GitLab repository id can be resolved', async () => {
+        getApplicationDetailsInfoByParams.mockResolvedValue(
+            application('https://gitlab.com/ekino/v6y'),
+        );
+        getRepositoryDetails.mockResolvedValue(null);
+
+        const outcome = await DoraMetricsAuditor.startAuditorAnalysis({ applicationId: 1 });
+
+        expect(outcome.status).toBe('skipped');
+        expect(getRepositoryDetails).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'gitlab' }),
+        );
+        expect(insertAuditList).not.toHaveBeenCalled();
+    });
+
+    it('fails when the application cannot be found', async () => {
+        getApplicationDetailsInfoByParams.mockResolvedValue(null);
+
+        const outcome = await DoraMetricsAuditor.startAuditorAnalysis({ applicationId: 404 });
+
+        expect(outcome.status).toBe('failed');
+    });
+});

--- a/v6y-apps/bfb-devops-auditor/src/auditors/dora-metrics/DoraMetricsAuditor.ts
+++ b/v6y-apps/bfb-devops-auditor/src/auditors/dora-metrics/DoraMetricsAuditor.ts
@@ -46,15 +46,31 @@ const startAuditorAnalysis = async ({
             `[DoraMetricsAuditor - startAuditorAnalysis] application _id:  ${application?._id}`,
         );
 
+        // DORA metrics are computed from GitLab-only endpoints
+        // (projects/:id/deployments and /merge_requests). GithubConfig exposes no
+        // equivalent, and startDoraMetricsAnalysis below fetches with the default
+        // 'gitlab' type, so resolving a GitHub repository id would query GitLab with a
+        // GitHub id: every request fails, and empty metrics get reported as a success.
+        // Skip explicitly instead, until GitHub DORA endpoints actually exist.
+        if (application.repo?.webUrl?.includes('github.com')) {
+            AppLogger.warn(
+                `[DoraMetricsAuditor - startAuditorAnalysis] GitHub-hosted repository, skipping Dora metrics audit`,
+            );
+            return {
+                status: 'skipped',
+                message: 'DORA metrics are only available for GitLab-hosted repositories.',
+            };
+        }
+
         const repositoryDetails = await RepositoryApi.getRepositoryDetails({
             organization: application.repo?.organization,
             gitRepositoryName: application.repo?.gitUrl?.split('/').pop()?.replace('.git', ''),
-            type: application.repo?.webUrl?.includes('github.com') ? 'github' : 'gitlab',
+            type: 'gitlab',
         });
 
         if (!repositoryDetails?.id) {
-            // Not a failure: DORA metrics are GitLab-only, so a project without a
-            // resolvable GitLab id simply has nothing to audit here.
+            // Not a failure: a project with no resolvable GitLab id simply has nothing
+            // to audit here.
             AppLogger.warn(
                 `[DoraMetricsAuditor - startAuditorAnalysis] repository id is missing, skipping Dora metrics audit`,
             );


### PR DESCRIPTION
Targets the #413 branch. Fixes two regressions that the merge itself created — not findings that anyone missed.

Both of us fixed the same two findings independently, with opposite resolutions, and merging #454 on top of `5545e177` combined them. The result does not run.

## The stack cannot start

The env templates kept `4002` for the main analyzer, `docker-compose.yml` kept `4005`. So `v6y-bfb-main-analyzer` and `v6y-bfb-devops-auditor` both map host port `4005:4005` — `docker compose up` fails on a port allocation conflict before anything boots.

Underneath that, the same inconsistency breaks the service even if the ports are freed: the container binds `V6Y_MAIN_API_PORT`, which every template now sets to `4002`, while the port mapping, the healthcheck and the BFF's trigger URL all pointed at `4005`. The trigger would get `ECONNREFUSED`, the healthcheck would never pass, and anything waiting on `service_healthy` would block.

Aligned compose on **4002** — the `ServerConfig` default in both branches, and what all three templates already say. `4005` stays the devops auditor's port, which is what it was always meant to be.

## GitHub DORA metrics reported empty data as a success

Detecting the repository host from `repo.webUrl` and teaching `getRepositoryDetails` about GitHub's object response shape means a GitHub repository now resolves an id. That is a correct change on its own, but it removes the condition the skip guard relied on, so the audit proceeds.

It cannot proceed usefully. DORA is computed from GitLab-only endpoints: `GithubConfig.urls` exposes only `fileContentUrl` and `repositoryDetailsUrl` — no deployments, no merge requests — and `startDoraMetricsAnalysis` calls `getRepositoryDeployments` / `getRepositoryMergeRequests` without a `type`, so both default to `'gitlab'` and cast to `GitlabConfigType`. A GitHub repository id was therefore queried against GitLab, every request came back empty, the metrics were computed from nothing, stored, and reported as `success`.

That is the same false success the original finding was about, arrived at from the other direction: instead of failing every GitHub app, it now silently fabricates empty DORA metrics for them.

GitHub-hosted repositories are now skipped explicitly, before details are resolved, until GitHub DORA endpoints actually exist. The object-shape support in `getRepositoryDetails` stays — it is correct, and `ApplicationManager` calls that function too.

Three new `DoraMetricsAuditor` tests cover the GitHub skip, the unresolvable-id skip, and the unknown-application failure.

## Everything else merged cleanly

Worth stating explicitly, since the two rounds overlapped heavily:

- The poller kept the `_id` comparison, with the `<=` form rather than `===` — slightly stricter, so an older run resurfacing cannot pass either.
- `GraphQLClient` kept the lazy `getGqlClient`, the absolute-URL requirement outside the browser, and no hardcoded SSR origin.
- The BullMQ migration is intact: 16 queue files, the three auditor queues, `data-update`, `QueueJobHelper`, and the explicit `@Inject` tokens in all three auditor controllers.
- The `GithubConfigType.headers.Authorization` compile fix landed once, not twice.

## Verification

- `nx run-many --target=build:tsc --all` — 9 projects, clean.
- `nx run-many --target=lint --all` — 10 projects, clean.
- `nx run-many --target=test --all` — 9 projects green.
- `prettier --check` — clean.
- Port mappings re-checked for duplicate host ports: none.

The Docker stack itself is still not booted here. The port collision was found by reading compose, and it is the kind of thing worth confirming with one `docker compose up` before merging.
