### PR TITLE
[CHORE]: stop duplicating Build/Lint/Test CI runs on push + pull_request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - "**"
+      - "main"
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - "**"
+      - "main"
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - "**"
+      - "main"
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
## Description
`Build`, `Lint`, and `Test` GitHub Actions workflows each declared both:
```yaml
on:
  push:
    branches: ["**"]
  pull_request:
    branches: ["**"]
```
Since `branches: ["**"]` matches every branch, pushing a feature branch fires the `push` run, and opening/updating a PR against `main` fires a *second*, separate `pull_request` run for the exact same commit — so every PR ran 3 workflows twice each (6 runs total instead of 3).

This restricts the `push` trigger on these three workflows to `main` only, so it only fires post-merge, while `pull_request` (still matching `branches: ["**"]`) covers all in-progress branch work. This matches the convention already used by `docker-publish.yml` (`push: branches: ["main"]`) and `knip.yml` (`push`/`pull_request` both scoped to `[main, develop]`), which don't have this duplication issue.

No functional/build changes — CI config only.

##  Checklist
- [x] I have read and followed the [Contribution Guide](https://github.com/ekino/v6y/wiki/Contribution-Guide).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Contextual Links (optional)
Found while reviewing CI runs on #457.

## Reviewers
Please assign at least one reviewer for this PR.
