### PR TITLE
[FIX]: Next.js dev RAM bloat, NestJS resource leaks, and i18n hydration mismatch

### DIFF
--- a/v6y-apps/bfb-dynamic-auditor/src/auditors/lighthouse/LighthouseAuditor.ts
+++ b/v6y-apps/bfb-dynamic-auditor/src/auditors/lighthouse/LighthouseAuditor.ts
@@ -18,14 +18,15 @@ const { formatLighthouseReports } = LighthouseUtils;
  * @param auditConfig
  */
 const startLighthouseAudit = async (auditConfig: LighthouseAuditConfigType) => {
-    try {
-        // open browser
-        const { link, browserPath, lightHouseConfig } = auditConfig || {};
-        if (!link || !browserPath || !lightHouseConfig) {
-            return null;
-        }
+    // open browser
+    const { link, browserPath, lightHouseConfig } = auditConfig || {};
+    if (!link || !browserPath || !lightHouseConfig) {
+        return null;
+    }
 
-        const browser = await puppeteer.launch({
+    let browser: Awaited<ReturnType<typeof puppeteer.launch>> | undefined;
+    try {
+        browser = await puppeteer.launch({
             ...PUPPETEER_SETTINGS,
             executablePath: browserPath,
         });
@@ -60,15 +61,22 @@ const startLighthouseAudit = async (auditConfig: LighthouseAuditConfigType) => {
             ).join(', ')}`,
         );
 
-        // close browser
-        await browser.close();
-        AppLogger.info(`[LightHouseAuditor - startLighthouseAudit] browser closed`);
-
         // lighthouse json report
         return report;
     } catch (error) {
         AppLogger.info(`[LightHouseAuditor - startLighthouseAudit] error:  ${error}`);
         return null;
+    } finally {
+        // Always close the browser, even on error/timeout, otherwise the headless
+        // Chromium process is orphaned and keeps consuming memory indefinitely.
+        if (browser) {
+            await browser.close().catch((closeError) => {
+                AppLogger.info(
+                    `[LightHouseAuditor - startLighthouseAudit] error closing browser:  ${closeError}`,
+                );
+            });
+            AppLogger.info(`[LightHouseAuditor - startLighthouseAudit] browser closed`);
+        }
     }
 };
 

--- a/v6y-apps/front-bo/next.config.mjs
+++ b/v6y-apps/front-bo/next.config.mjs
@@ -14,6 +14,14 @@ const nextConfig = {
     turbopack: {
         root: workspaceRoot,
     },
+    experimental: {
+        // Turbopack's dev persistent cache (.next/dev/cache) grows unbounded across
+        // long-running local dev sessions (observed several GB) and inflates the
+        // next-server process's resident memory. Disabling it only slows down warm
+        // starts after a restart; incremental rebuilds within a running session are
+        // unaffected. See https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache
+        turbopackFileSystemCacheForDev: false,
+    },
     transpilePackages: ['@refinedev/antd'],
     webpack(config, { isServer }) {
         if (!isServer) {

--- a/v6y-apps/front-bo/src/infrastructure/providers/AppProvider.tsx
+++ b/v6y-apps/front-bo/src/infrastructure/providers/AppProvider.tsx
@@ -1,27 +1,37 @@
 'use client';
 
 import * as React from 'react';
+import { useEffect } from 'react';
 
 import { AdminProvider } from '@v6y/ui-kit';
 
 import VitalityPageLayout from '../../commons/components/layout/VitalityPageLayout';
 import { VitalityRoutes } from '../../commons/config/VitalityNavigationConfig';
-import '../translation/i18nHelper';
+import { applyDetectedLocale } from '../translation/i18nHelper';
 import { gqlAuthProvider, gqlDataProvider, gqlLiveProvider } from './GraphQLProvider';
 
 type AppProviderProps = {
     children: React.ReactNode;
 };
 
-const AppProvider = ({ children }: AppProviderProps) => (
-    <AdminProvider
-        dataProvider={gqlDataProvider}
-        liveProvider={gqlLiveProvider}
-        authProvider={gqlAuthProvider}
-        resources={VitalityRoutes}
-    >
-        <VitalityPageLayout>{children}</VitalityPageLayout>
-    </AdminProvider>
-);
+const AppProvider = ({ children }: AppProviderProps) => {
+    // Switch to the user's real cached locale only after the initial,
+    // hydration-safe render (see i18nHelper.ts for why the app boots with
+    // the SSR fallback locale).
+    useEffect(() => {
+        applyDetectedLocale();
+    }, []);
+
+    return (
+        <AdminProvider
+            dataProvider={gqlDataProvider}
+            liveProvider={gqlLiveProvider}
+            authProvider={gqlAuthProvider}
+            resources={VitalityRoutes}
+        >
+            <VitalityPageLayout>{children}</VitalityPageLayout>
+        </AdminProvider>
+    );
+};
 
 export default AppProvider;

--- a/v6y-apps/front-bo/src/infrastructure/translation/i18nHelper.ts
+++ b/v6y-apps/front-bo/src/infrastructure/translation/i18nHelper.ts
@@ -51,6 +51,8 @@ const DETECTION_OPTIONS = {
     caches: ['localStorage', 'cookie'],
 };
 
+const FALLBACK_LOCALE = 'en';
+
 i18next
     .use(initReactI18next)
     .use(LanguageDetector)
@@ -61,11 +63,38 @@ i18next
         ),
     )
     .init({
+        // Boot with the SSR fallback locale explicitly: passing `lng` makes
+        // i18next skip `LanguageDetector`'s synchronous detect() call at
+        // init time. Without this, the detector resolves a cached locale
+        // (e.g. 'fr' from localStorage/cookies) before React starts
+        // hydrating, so any component rendering translated text mismatches
+        // the server's fallback-only render, throwing a hydration error.
+        // The real cached locale is applied after mount instead, via
+        // `applyDetectedLocale()` below.
+        lng: FALLBACK_LOCALE,
         supportedLngs: ['en', 'fr'],
-        fallbackLng: 'en',
+        fallbackLng: FALLBACK_LOCALE,
         detection: DETECTION_OPTIONS,
         defaultNS: 'common',
         react: {
             useSuspense: false,
         },
     });
+
+/**
+ * Client-only: resolves the user's previously detected/cached locale (via
+ * the same `i18next-browser-languagedetector` instance registered above)
+ * and switches to it. Must be called after the initial hydration-safe
+ * render (e.g. from a `useEffect`) so the language change happens as a
+ * normal client-side update rather than during hydration comparison.
+ */
+export const applyDetectedLocale = () => {
+    if (typeof window === 'undefined') return;
+
+    const detected = i18next.services.languageDetector?.detect();
+    const detectedLocale = Array.isArray(detected) ? detected[0] : detected;
+
+    if (detectedLocale && detectedLocale !== i18next.language) {
+        i18next.changeLanguage(detectedLocale);
+    }
+};

--- a/v6y-apps/front/next.config.mjs
+++ b/v6y-apps/front/next.config.mjs
@@ -28,6 +28,14 @@ const nextConfig = {
     turbopack: {
         root: workspaceRoot,
     },
+    experimental: {
+        // Turbopack's dev persistent cache (.next/dev/cache) grows unbounded across
+        // long-running local dev sessions (observed several GB) and inflates the
+        // next-server process's resident memory. Disabling it only slows down warm
+        // starts after a restart; incremental rebuilds within a running session are
+        // unaffected. See https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache
+        turbopackFileSystemCacheForDev: false,
+    },
     async redirects() {
         return [
             {

--- a/v6y-apps/front/src/infrastructure/providers/AppProvider.tsx
+++ b/v6y-apps/front/src/infrastructure/providers/AppProvider.tsx
@@ -1,12 +1,21 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { ThemeModes, ThemeProvider, ThemeTypes } from '@v6y/ui-kit';
 import { ThemeProps } from '@v6y/ui-kit/src/theme/types/ThemeProps';
 
-import '../translation/i18nHelper';
+import { applyDetectedLocale } from '../translation/i18nHelper';
 import QueryProvider from './QueryProvider';
 
 export const AppProvider = ({ children }: ThemeProps) => {
+    // Switch to the user's real cached locale only after the initial,
+    // hydration-safe render (see i18nHelper.ts for why the app boots with
+    // the SSR fallback locale).
+    useEffect(() => {
+        applyDetectedLocale();
+    }, []);
+
     return (
         <QueryProvider>
             <ThemeProvider

--- a/v6y-apps/front/src/infrastructure/translation/i18nHelper.ts
+++ b/v6y-apps/front/src/infrastructure/translation/i18nHelper.ts
@@ -19,6 +19,8 @@ const DETECTION_OPTIONS = {
     caches: ['localStorage', 'cookie'],
 };
 
+const FALLBACK_LOCALE = 'en';
+
 if (!i18next.isInitialized) {
     i18next
         .use(initReactI18next)
@@ -30,11 +32,38 @@ if (!i18next.isInitialized) {
             ),
         )
         .init({
+            // Boot with the SSR fallback locale explicitly: passing `lng`
+            // makes i18next skip `LanguageDetector`'s synchronous detect()
+            // call at init time. Without this, the detector resolves a
+            // cached locale (e.g. 'fr' from localStorage/cookies) before
+            // React starts hydrating, so any component rendering translated
+            // text mismatches the server's fallback-only render, throwing a
+            // hydration error. The real cached locale is applied after
+            // mount instead, via `applyDetectedLocale()` below.
+            lng: FALLBACK_LOCALE,
             supportedLngs: ['en', 'fr'],
-            fallbackLng: 'en',
+            fallbackLng: FALLBACK_LOCALE,
             detection: DETECTION_OPTIONS,
             defaultNS: 'common',
         });
 }
+
+/**
+ * Client-only: resolves the user's previously detected/cached locale (via
+ * the same `i18next-browser-languagedetector` instance registered above)
+ * and switches to it. Must be called after the initial hydration-safe
+ * render (e.g. from a `useEffect`) so the language change happens as a
+ * normal client-side update rather than during hydration comparison.
+ */
+export const applyDetectedLocale = () => {
+    if (typeof window === 'undefined') return;
+
+    const detected = i18next.services.languageDetector?.detect();
+    const detectedLocale = Array.isArray(detected) ? detected[0] : detected;
+
+    if (detectedLocale && detectedLocale !== i18next.language) {
+        i18next.changeLanguage(detectedLocale);
+    }
+};
 
 export default i18next;

--- a/v6y-libs/core-logic/src/core/WorkerHelper.ts
+++ b/v6y-libs/core-logic/src/core/WorkerHelper.ts
@@ -21,13 +21,29 @@ const forkWorker = (filepath: string, workerData: WorkerOptions['workerData']) =
                   { eval: true, workerData },
               )
             : new Worker(absolutePath, { workerData });
+
+        // The worker keeps a DB connection pool (and possibly other open handles)
+        // alive, so its event loop never drains on its own and the thread never
+        // emits 'exit' by itself. Without an explicit terminate() the worker (and
+        // its own V8 heap + DB connections) would stay resident in memory forever,
+        // leaking a little more with every audit run.
+        const terminateWorker = () => {
+            worker.terminate().catch(() => {
+                // Already exited/terminated — nothing to clean up.
+            });
+        };
+
         worker.on('online', () => {
             console.log('******************** Launching intensive CPU task ******************** ');
         });
         worker.on('message', (messageFromWorker) => {
-            return resolve(messageFromWorker);
+            resolve(messageFromWorker);
+            terminateWorker();
         });
-        worker.on('error', reject);
+        worker.on('error', (error) => {
+            reject(error);
+            terminateWorker();
+        });
         worker.on('exit', (code) => {
             if (code !== 0) {
                 reject(new Error(`Worker stopped with exit code ${code}`));

--- a/v6y-libs/ui-kit-front/src/components/organisms/LanguageMenu.tsx
+++ b/v6y-libs/ui-kit-front/src/components/organisms/LanguageMenu.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { useIsClient } from '../../hooks/useIsClient';
 import { useTranslationProvider } from '../../translation/useTranslationProvider';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../molecules';
 
@@ -22,7 +23,16 @@ const Flag = ({ code, label }: { code: string; label: string }) => (
 
 const LanguageMenu = () => {
     const { getLocale, changeLocale } = useTranslationProvider();
-    const currentLocale = getLocale();
+    // i18next-browser-languagedetector only has access to localStorage/cookies
+    // on the client, so the server always renders the `fallbackLng` ('en')
+    // while the client can resolve a different cached locale (e.g. 'fr')
+    // during the very first render pass. Rendering that client-only value
+    // immediately would make hydration compare mismatched markup (wrong flag
+    // image/label) against the server HTML. Gate on `useIsClient()` so the
+    // first client render still matches the server's 'en' output, then swap
+    // to the real locale right after hydration completes.
+    const isClient = useIsClient();
+    const currentLocale = isClient ? getLocale() : 'en';
     const currentLanguage = languages.find((lang) => lang.code === currentLocale) || languages[0];
 
     return (

--- a/v6y-libs/ui-kit-front/src/hooks/index.ts
+++ b/v6y-libs/ui-kit-front/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useIsClient';
 export * from './useNavigationAdapter';

--- a/v6y-libs/ui-kit-front/src/hooks/useIsClient.ts
+++ b/v6y-libs/ui-kit-front/src/hooks/useIsClient.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const emptySubscribe = () => () => {};
+
+/**
+ * Returns true only once the component has hydrated on the client.
+ * Prefer this over a `useState` + `useEffect` "mounted" flag: relying on
+ * `useSyncExternalStore`'s server/client snapshots avoids triggering a
+ * synchronous `setState` call inside an effect (react-hooks/set-state-in-effect).
+ */
+export const useIsClient = () =>
+    useSyncExternalStore(
+        emptySubscribe,
+        () => true,
+        () => false,
+    );


### PR DESCRIPTION
## Summary

Fixes three unrelated issues found while auditing local dev RAM usage and a reported hydration error:

- **Next.js dev RAM bloat**: Turbopack's persistent dev filesystem cache (`experimental.turbopackFileSystemCacheForDev`) grew unbounded (5.9GB/2.1GB observed for `front`/`front-bo`), directly inflating `next-server` process RSS. Disabled in both apps' `next.config.mjs`.
- **NestJS resource leaks**:
  - `LighthouseAuditor`: the puppeteer browser was only closed on the success path, orphaning a resident headless Chromium process on any thrown error. Now closed in a `finally` block.
  - `WorkerHelper.forkWorker`: worker threads never called `.terminate()`, and every audit worker connects to the DB but never disconnects — so the worker's own connection pool kept its event loop alive forever. Now explicitly terminated once the result settles (fixes the leak for all 9 audit worker types that use this helper).
- **i18n SSR hydration mismatch**: `i18next-browser-languagedetector` resolves the cached locale (e.g. 'fr') synchronously before hydration, while the server always renders the fallback ('en'), causing a hydration error on any component rendering translated text (seen in the language switcher and breadcrumb). Both apps now boot i18next with the fallback locale explicitly and apply the real cached locale after mount instead.

## Testing

- Lint clean on all touched projects; pre-push hook ran the full test/lint suite successfully.
- Verified Turbopack cache fix via a live dev-server boot (`.next` size stayed at a few MB instead of GBs).
- Verified `LighthouseAuditor`/`WorkerHelper` fixes via their existing test suites (37/37, 43/43).
- Verified the i18n fix via lint + type-check + a live dev-server smoke test (SSR still renders the fallback locale correctly).
