### PR TITLE
feat(back-office): add read/write field adapters for accounts/applications/evolutionHelps

### DIFF
--- a/v6y-apps/back-office/src/core/providers/dataProvider.ts
+++ b/v6y-apps/back-office/src/core/providers/dataProvider.ts
@@ -69,6 +69,9 @@ export const dataProvider: DataProvider = {
             variables,
         );
         let data = (result[resource.graphql.listField] ?? []).map(withRaId);
+        if (resource.parseRecord) {
+            data = data.map((record) => withRaId(resource.parseRecord!(record)));
+        }
 
         // Basic full text filter (matches ra-core's `filter: { q: '...' }` convention).
         const query = typeof params.filter?.q === 'string' ? params.filter.q.toLowerCase() : '';
@@ -110,7 +113,8 @@ export const dataProvider: DataProvider = {
         if (!record) {
             throw new Error(`${resourceName} #${params.id} not found`);
         }
-        return { data: withRaId(record) as unknown as RecordType };
+        const parsedRecord = resource.parseRecord ? resource.parseRecord(record) : record;
+        return { data: withRaId(parsedRecord) as unknown as RecordType };
     },
 
     async getMany(resourceName: string, params: GetManyParams) {
@@ -139,9 +143,12 @@ export const dataProvider: DataProvider = {
             throw new Error(`Resource "${resourceName}" does not support create`);
         }
         const client = createAuthenticatedGraphQLClient();
+        const inputData = resource.serializeInput
+            ? resource.serializeInput(params.data as Record<string, unknown>)
+            : params.data;
         const result = await client.request<Record<string, Record<string, unknown>>>(
             resource.graphql.createOrEditMutation,
-            { [resource.graphql.createOrEditArgName as string]: params.data },
+            { [resource.graphql.createOrEditArgName as string]: inputData },
         );
         return {
             data: withRaId(
@@ -159,11 +166,14 @@ export const dataProvider: DataProvider = {
             throw new Error(`Resource "${resourceName}" does not support update`);
         }
         const client = createAuthenticatedGraphQLClient();
+        const inputData = resource.serializeInput
+            ? resource.serializeInput(params.data as Record<string, unknown>)
+            : (params.data as Record<string, unknown>);
         const result = await client.request<Record<string, Record<string, unknown>>>(
             resource.graphql.createOrEditMutation,
             {
                 [resource.graphql.createOrEditArgName as string]: {
-                    ...(params.data as Record<string, unknown>),
+                    ...inputData,
                     _id: Number(params.id),
                 },
             },

--- a/v6y-apps/back-office/src/core/resources/accounts.ts
+++ b/v6y-apps/back-office/src/core/resources/accounts.ts
@@ -75,6 +75,22 @@ const accounts: ResourceConfig = {
         `,
         deleteField: 'deleteAccount',
     },
+    // BFF's `applications` field is `[Int]`; the form edits it as one
+    // comma-separated string of application ids.
+    parseRecord: (record) => ({
+        ...record,
+        applications: Array.isArray(record.applications) ? record.applications.join(', ') : '',
+    }),
+    serializeInput: (data) => ({
+        ...data,
+        applications:
+            typeof data.applications === 'string'
+                ? data.applications
+                      .split(',')
+                      .map((value) => Number(value.trim()))
+                      .filter((value) => !Number.isNaN(value))
+                : [],
+    }),
 };
 
 export default accounts;

--- a/v6y-apps/back-office/src/core/resources/applications.ts
+++ b/v6y-apps/back-office/src/core/resources/applications.ts
@@ -123,6 +123,30 @@ const applications: ResourceConfig = {
         `,
         deleteField: 'deleteApplication',
     },
+    // The detail query returns gitOrganization/gitWebUrl/gitUrl and the DataDog
+    // keys nested under `repo`/`configuration.dataDog`, but the create/edit
+    // mutation (and this generic form) expects them as flat fields - flatten on
+    // read, the write side already matches the mutation input as-is.
+    // Note: productionLink, sonarqubeLink, codeQualityPlatformLink,
+    // ciPlatformLink, deploymentPlatformLink and sonarqubeToken are write-only
+    // in the BFF schema (ApplicationType exposes none of them), so those fields
+    // always render blank when editing an existing application - this is a BFF
+    // read-schema gap, not fixable from the admin alone.
+    parseRecord: (record) => {
+        const repo = (record.repo ?? {}) as Record<string, unknown>;
+        const configuration = (record.configuration ?? {}) as Record<string, unknown>;
+        const dataDog = (configuration.dataDog ?? {}) as Record<string, unknown>;
+        return {
+            ...record,
+            gitOrganization: repo.organization ?? '',
+            gitWebUrl: repo.webUrl ?? '',
+            gitUrl: repo.gitUrl ?? '',
+            dataDogApiKey: dataDog.apiKey ?? '',
+            dataDogAppKey: dataDog.appKey ?? '',
+            dataDogUrl: dataDog.url ?? '',
+            dataDogMonitorId: dataDog.monitorId ?? '',
+        };
+    },
 };
 
 export default applications;

--- a/v6y-apps/back-office/src/core/resources/evolutionHelps.ts
+++ b/v6y-apps/back-office/src/core/resources/evolutionHelps.ts
@@ -14,8 +14,17 @@ const evolutionHelps: ResourceConfig = {
         {
             name: 'status',
             label: 'Status',
-            type: 'text',
+            type: 'select',
             required: true,
+            // Mirrors @v6y/core-logic's `evolutionHelpStatus` map
+            // (v6y-libs/core-logic/src/config/EvolutionHelpConfig.ts). Static
+            // here rather than fetched via `getEvolutionHelpStatus` since the
+            // set is small and fixed.
+            options: [
+                { label: 'Critical', value: 'critical' },
+                { label: 'Important', value: 'important' },
+                { label: 'Recommended', value: 'recommended' },
+            ],
         },
         { name: 'links', label: 'Extra links', type: 'links', hideInList: true },
     ],

--- a/v6y-apps/back-office/src/core/resources/types.ts
+++ b/v6y-apps/back-office/src/core/resources/types.ts
@@ -67,6 +67,19 @@ export interface ResourceConfig {
     graphql: ResourceGraphQLConfig;
     canCreate: boolean;
     canDelete: boolean;
+    /**
+     * Adapts a raw BFF record (already carrying `id`) into the flat shape the
+     * generic form/list/show components expect, e.g. flattening nested
+     * `repo`/`configuration` objects or turning an int array into a display
+     * string. Applied after every read (getList/getOne).
+     */
+    parseRecord?: (record: Record<string, unknown>) => Record<string, unknown>;
+    /**
+     * Adapts form values back into the shape the create/update mutation input
+     * expects, e.g. turning a comma-separated string back into an int array.
+     * Applied before every write (create/update).
+     */
+    serializeInput?: (data: Record<string, unknown>) => Record<string, unknown>;
 }
 
 export interface RaRecordLike {


### PR DESCRIPTION
## Summary

Second of a 3-PR stack (see #470). Builds on the base back-office app to add read/write field adapters (`parseRecord`/`serializeInput`) so complex fields round-trip correctly through the admin forms.

### What's included
- `ResourceConfig` gains optional `parseRecord`/`serializeInput` hooks (applied in `dataProvider`'s `getList`/`getOne`/`create`/`update`).
- `accounts.ts`: `applications` field converts between a comma-separated string (form) and an array of IDs (API).
- `applications.ts`: `parseRecord` flattens `repo`/`configuration.dataDog` nested objects onto flat form fields; documents which fields are write-only in the current BFF read schema (productionLink, sonarqubeLink, codeQualityPlatformLink, ciPlatformLink, deploymentPlatformLink, sonarqubeToken).
- `evolutionHelps.ts`: `status` becomes a `select` field (Critical/Important/Recommended) instead of free text.

### Stack
1. `feat/back-office-admin-app` (#470) — base admin app
2. **#this** — resource adapters
3. `chore/remove-front-bo` → resource adapters — removes `front-bo`, finalizes ports

### Verification
- `tsc --noEmit`, `eslint` pass.
- Adapter logic verified byte-identical (via diff) against the original single-session implementation before it was split out.